### PR TITLE
adding `apt-get upgrade` to pull package updates

### DIFF
--- a/compute-labs/worker-startup-script.sh
+++ b/compute-labs/worker-startup-script.sh
@@ -10,7 +10,7 @@ set -x
 #
 # Make sure installed packages are up to date with all security patches.
 #
-apt-get update
+apt-get update && apt-get upgrade
 
 
 #


### PR DESCRIPTION
The existing line will pull the most recent definitions of packages but won't actually upgrade them as suggested in the comment.