### PR TITLE
make apt-get upgrade work unprompted

### DIFF
--- a/compute-labs/worker-startup-script.sh
+++ b/compute-labs/worker-startup-script.sh
@@ -10,7 +10,7 @@ set -x
 #
 # Make sure installed packages are up to date with all security patches.
 #
-apt-get update && apt-get upgrade
+apt-get update && apt-get upgrade -y
 
 
 #


### PR DESCRIPTION
I goofed with the last one- apt-get upgrade will prompt by default.  The `-y` flag will default to upgrading.