### PR TITLE
Fix: updating grub can result in stuck startup scripts.

### DIFF
--- a/compute-labs/worker-startup-script.sh
+++ b/compute-labs/worker-startup-script.sh
@@ -5,7 +5,7 @@
 # GCE startup script output shows up in "/var/log/syslog" .
 #
 set -x
-
+export DEBIAN_FRONTEND=noninteractive
 
 #
 # Make sure installed packages are up to date with all security patches.


### PR DESCRIPTION
Please take a look, this may help folks getting stuck by this issue.

Reference: https://serverfault.com/questions/941031/how-to-fix-setting-up-grub-pc-freezing-during-apt-get-upgrade