### PR TITLE
Updated gsutil cp of worker_log_file to worker_log_bucket

### DIFF
--- a/compute-labs/worker-startup-script.sh
+++ b/compute-labs/worker-startup-script.sh
@@ -50,4 +50,4 @@ echo "Phew!  Work completed at $(date)" >"${worker_log_file}"
 
 # And we copy that file to the bucket specified in the metadata.
 echo "Copying the log file to the bucket..."
-gsutil cp "${worker_log_file}" "${worker_log_bucket}"
+gsutil cp "${worker_log_file}" "gs://${worker_log_bucket}/"


### PR DESCRIPTION
Before the changes present in this PR the copy would return `Operation completed over 1 objects/54.0 B.` but nothing would be in the storage bucket. After adding scheme (gs://) and a trailing slash to the destination url fix the `gsutil cp` command.