### PR TITLE
Disable man-db updates fixes #5

### DIFF
--- a/compute-labs/worker-startup-script.sh
+++ b/compute-labs/worker-startup-script.sh
@@ -12,6 +12,9 @@ set -x
 #
 export DEBIAN_FRONTEND=noninteractive
 
+# Disable man-db updates triggered by package updates or installation,
+# which can take a long time on small instances.
+[[ -e /var/lib/man-db/auto-update ]] && rm -f /var/lib/man-db/auto-update 
 
 #
 # Make sure installed packages are up to date with all security patches.


### PR DESCRIPTION
Disable man-db updates initiated the man-db package postinst or
trigger.

This can speed up the first instance startup of an instance using this
script by several minutes on some instance types (notably f1-micro, used
often in the course labs).